### PR TITLE
Make TydFileExtension publically accessible

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,7 +1,7 @@
 namespace Tyd
 {
 
-internal static class Constants
+public static class Constants
 {
     //Constants - public
     public static string    TydFileExtension        = ".tyd";


### PR DESCRIPTION
It was previously de facto internal due to class Constants being
internal, in contradiction to intention stated by access modifier and
code comment.